### PR TITLE
Change key-value input to allow quoted and/or escaped split characters and colons

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
-updates: []
-#   - package-ecosystem: "npm" # See documentation for possible values
-#     directory: "/" # Location of package manifests
-#     schedule:
-#       interval: "weekly"
-#     labels:
-#       - automerge
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    ignore:
+      - dependency-name: "@opentelemetry/*" # ignore otel dependencies until patches aren't needed
+    schedule:
+      interval: "weekly"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-extension-for-opentelemetry",
   "displayName": "Browser Extension for OpenTelemetry",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "A browser extension for automatically instrumenting webpages using OpenTelemetry",
   "author": "Theodore Brockman <iam@theo.lol>",
   "packageManager": "pnpm@9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-extension-for-opentelemetry",
   "displayName": "Browser Extension for OpenTelemetry",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "A browser extension for automatically instrumenting webpages using OpenTelemetry",
   "author": "Theodore Brockman <iam@theo.lol>",
   "packageManager": "pnpm@9.4.0",
@@ -41,8 +41,7 @@
     "@opentelemetry/sdk-trace-base": "^1.22.0",
     "@opentelemetry/sdk-trace-web": "^1.22.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
-    "@plasmohq/messaging": "^0.6.2",
-    "@tabler/icons-react": "^2.47.0",
+    "@tabler/icons-react": "^3.14.0",
     "browser-extension-url-match": "^1.2.0",
     "deepmerge-ts": "^7.0.3",
     "react": "18.2.0",
@@ -54,21 +53,21 @@
     "@parcel/config-default": "^2.12.0",
     "@parcel/packager-ts": "2.12.0",
     "@plasmohq/parcel-config": "^0.41.0",
-    "@types/chrome": "0.0.262",
+    "@types/chrome": "0.0.270",
     "@types/jest": "^29.5.12",
     "@types/mocha": "^10.0.7",
-    "@types/node": "20.11.24",
+    "@types/node": "22.5.4",
     "@types/react": "18.2.61",
     "@types/react-dom": "18.2.19",
     "cross-env": "^7.0.3",
-    "esbuild": "^0.20.1",
+    "esbuild": "^0.23.1",
     "esbuild-plugin-polyfill-node": "^0.3.0",
     "mocha": "^10.5.2",
     "mocha-suppress-logs": "^0.5.1",
     "npm-run-all": "^4.1.5",
     "parcel": "^2.12.0",
     "parcel-resolver-inlinefunc": "^1.0.0",
-    "plasmo": "^0.88.0",
+    "plasmo": "^0.89.1",
     "postcss": "^8.4.35",
     "postcss-preset-mantine": "^1.13.0",
     "postcss-simple-vars": "^7.0.1",
@@ -92,6 +91,13 @@
     "browser_specific_settings": {
       "gecko": {
         "id": "opentelemetry-browser-extension@theo.lol"
+      }
+    },
+    "overrides": {
+      "firefox": {
+        "content_security_policy": {
+          "extension_pages": "script-src 'self'; object-src 'self'; connect-src *; style-src 'self' 'unsafe-inline'; default-src 'self'; "
+        }
       }
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.22.0
         version: 1.25.1
-      '@plasmohq/messaging':
-        specifier: ^0.6.2
-        version: 0.6.2(react@18.2.0)
       '@tabler/icons-react':
         specifier: ^2.47.0
         version: 2.47.0(react@18.2.0)
@@ -165,8 +162,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(@parcel/core@2.9.3)
       plasmo:
-        specifier: ^0.88.0
-        version: 0.88.0(@swc/core@1.7.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)(lodash@4.17.21)(postcss@8.4.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.12))(@types/node@20.11.24)(typescript@5.3.3))
+        specifier: ^0.89.1
+        version: 0.89.1(@swc/core@1.7.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)(lodash@4.17.21)(postcss@8.4.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.12))(@types/node@20.11.24)(typescript@5.3.3))
       postcss:
         specifier: ^8.4.35
         version: 8.4.39
@@ -2172,14 +2169,6 @@ packages:
   '@plasmohq/init@0.7.0':
     resolution: {integrity: sha512-P75g48dqOGneJ+n0AcqnLE/TYflcaPc3B7h6EopnCBBYUDnCNBMwYmKAkaf5pnhsEB0ybPS6TU1C2DTGfqaW7A==}
 
-  '@plasmohq/messaging@0.6.2':
-    resolution: {integrity: sha512-CGfcvfVE0wsN/Y/i/jV0nwjkwh2gBCEujZFhLoxJ12N0ScoP3JVEIvUxJSFsAD4ylBQ8IjD2FyjQozwiSxWc4Q==}
-    peerDependencies:
-      react: ^16.8.6 || ^17 || ^18
-    peerDependenciesMeta:
-      react:
-        optional: true
-
   '@plasmohq/parcel-bundler@0.5.5':
     resolution: {integrity: sha512-QCMmmfic514CfdXMJ7JMWUnqDzIHKVKyYeqPpUDsXON6JvA1yTmO5mEQSls8+5u/HpocP9QmTskQOHu3RCNX9A==}
     engines: {node: '>= 16.0.0', parcel: '>= 2.7.0'}
@@ -4049,11 +4038,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.0.3:
-    resolution: {integrity: sha512-I7X2b22cxA4LIHXPSqbBCEQSL+1wv8TuoefejsX4HFWyC6jc5JG7CEaxOltiKjc1M+YCS2YkrZZcj4+dytw9GA==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
   napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
 
@@ -4259,8 +4243,8 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  plasmo@0.88.0:
-    resolution: {integrity: sha512-pL0xA9Y4zZuqQTyOwt0rQ8cahFMZI9toGMCa3aosB3dtzRztSe2rm3LA8hS52UdvnAUXm2A4ecmTlweaGN69Uw==}
+  plasmo@0.89.1:
+    resolution: {integrity: sha512-YBSi9QeXYo9UDcbpgNI+FBC19iWs9C66ucyZpop0MaW5rc+uv/6HHzINkw+NL2izfJ8bdEU0l3iCLhpBmeKP2A==}
     hasBin: true
 
   possible-typed-array-names@1.0.0:
@@ -6041,25 +6025,21 @@ snapshots:
       '@parcel/utils': 2.11.0
       lmdb: 2.8.5
 
-  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)':
+  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.12)
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
-  '@parcel/cache@2.12.0(@parcel/core@2.9.3)(@swc/helpers@0.5.12)':
+  '@parcel/cache@2.12.0(@parcel/core@2.9.3)':
     dependencies:
       '@parcel/core': 2.9.3
       '@parcel/fs': 2.12.0(@parcel/core@2.9.3)(@swc/helpers@0.5.12)
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@parcel/cache@2.8.3(@parcel/core@2.9.3)':
     dependencies:
@@ -6293,7 +6273,7 @@ snapshots:
   '@parcel/core@2.12.0(@swc/helpers@0.5.12)':
     dependencies:
       '@mischnic/json-sourcemap': 0.1.1
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       '@parcel/diagnostic': 2.12.0
       '@parcel/events': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
@@ -6428,7 +6408,7 @@ snapshots:
       '@parcel/fs-search': 2.9.3
       '@parcel/types': 2.9.3(@parcel/core@2.9.3)
       '@parcel/utils': 2.9.3
-      '@parcel/watcher': 2.2.0
+      '@parcel/watcher': 2.4.1
       '@parcel/workers': 2.9.3(@parcel/core@2.9.3)
 
   '@parcel/graph@2.9.3':
@@ -6830,7 +6810,7 @@ snapshots:
       '@parcel/types': 2.9.3(@parcel/core@2.9.3)
       '@parcel/utils': 2.9.3
       '@parcel/workers': 2.9.3(@parcel/core@2.9.3)
-      semver: 7.5.4
+      semver: 7.6.3
 
   '@parcel/packager-css@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))':
     dependencies:
@@ -7666,7 +7646,7 @@ snapshots:
 
   '@parcel/types@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)':
     dependencies:
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))
       '@parcel/diagnostic': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)
@@ -7679,7 +7659,7 @@ snapshots:
 
   '@parcel/types@2.12.0(@parcel/core@2.9.3)(@swc/helpers@0.5.12)':
     dependencies:
-      '@parcel/cache': 2.12.0(@parcel/core@2.9.3)(@swc/helpers@0.5.12)
+      '@parcel/cache': 2.12.0(@parcel/core@2.9.3)
       '@parcel/diagnostic': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.9.3)(@swc/helpers@0.5.12)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.9.3)(@swc/helpers@0.5.12)
@@ -7927,12 +7907,6 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   '@plasmohq/init@0.7.0': {}
-
-  '@plasmohq/messaging@0.6.2(react@18.2.0)':
-    dependencies:
-      nanoid: 5.0.3
-    optionalDependencies:
-      react: 18.2.0
 
   '@plasmohq/parcel-bundler@0.5.5':
     dependencies:
@@ -10238,8 +10212,6 @@ snapshots:
 
   nanoid@3.3.7: {}
 
-  nanoid@5.0.3: {}
-
   napi-build-utils@1.0.2: {}
 
   needle@3.3.1:
@@ -10252,7 +10224,7 @@ snapshots:
 
   node-abi@3.65.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.3
 
   node-addon-api@4.3.0: {}
 
@@ -10364,7 +10336,7 @@ snapshots:
       got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.5.4
+      semver: 7.6.3
 
   parcel-resolver-inlinefunc@1.0.0(@parcel/core@2.9.3):
     dependencies:
@@ -10458,7 +10430,7 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  plasmo@0.88.0(@swc/core@1.7.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)(lodash@4.17.21)(postcss@8.4.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.12))(@types/node@20.11.24)(typescript@5.3.3)):
+  plasmo@0.89.1(@swc/core@1.7.0(@swc/helpers@0.5.12))(@swc/helpers@0.5.12)(lodash@4.17.21)(postcss@8.4.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.7.0(@swc/helpers@0.5.12))(@types/node@20.11.24)(typescript@5.3.3)):
     dependencies:
       '@expo/spawn-async': 1.7.2
       '@parcel/core': 2.9.3
@@ -10905,7 +10877,7 @@ snapshots:
       detect-libc: 2.0.3
       node-addon-api: 6.1.0
       prebuild-install: 7.1.2
-      semver: 7.5.4
+      semver: 7.6.3
       simple-get: 4.0.1
       tar-fs: 3.0.6
       tunnel-agent: 0.6.0

--- a/src/components/GeneralConfiguration.tsx
+++ b/src/components/GeneralConfiguration.tsx
@@ -5,36 +5,10 @@ import { useLocalStorage } from "~hooks/storage";
 import { defaultOptions } from "~utils/options";
 import { matchPatternsChanged } from "~utils/match-pattern";
 import { setLocalStorage, type MatchPatternError } from "~utils/storage";
-import { parseKeyValuePairs } from "~utils/string";
-import { consoleProxy } from "~utils/logging";
+import { colonSeparatedStringsToMap, mapToColonSeparatedStrings } from "~utils/string";
 
 type GeneralConfigurationProps = {
     enabled: boolean
-}
-
-const colonSeparatedStringsToMap = (strings: string[]): Map<string, string> => {
-    const map = new Map<string, string>()
-    strings.forEach((string) => {
-        const [kvs, _] = parseKeyValuePairs(string, ',', false)
-        consoleProxy.debug('parsed kvs', kvs, 'for string', string)
-
-        kvs.forEach((value, key) => {
-            map.set(key, value)
-        })
-    })
-    consoleProxy.debug('converted strings to map', map)
-    return map
-}
-
-const mapToColonSeparatedStrings = (map: Map<string, string>): string[] => {
-    const strings = []
-    if (map) {
-        map.forEach((value, key) => {
-            strings.push(`${key}:${value}`)
-        })
-    }
-    consoleProxy.debug('converted map to strings', strings, 'from map', map)
-    return strings
 }
 
 const patternErrorsToPills = (patterns: string[], errors: MatchPatternError[]): Map<number, string> => {
@@ -120,9 +94,8 @@ export default function GeneralConfiguration({ enabled }: GeneralConfigurationPr
                 <TagsInput
                     value={attributesStrings}
                     onValueRemoved={(index) => {
-                        const newAttributes = [...attributesStrings]
-                        newAttributes.splice(index, 1)
-                        setLocalStorage({ attributes: colonSeparatedStringsToMap(newAttributes) })
+                        attributesStrings.splice(index, 1)
+                        setLocalStorage({ attributes: colonSeparatedStringsToMap(attributesStrings) })
                     }}
                     onValueAdded={(value) => {
                         attributesStrings.push(value)
@@ -133,16 +106,15 @@ export default function GeneralConfiguration({ enabled }: GeneralConfigurationPr
                     description="Attach additional attributes on all exported logs/traces."
                     placeholder={attributesStrings.length == 0 ? 'key:value, key2:value2' : ''}
                     delimiter={","}
+                    keyValueMode={true}
                 />
                 <TagsInput
                     value={headersStrings}
                     onValueRemoved={(index) => {
                         headersStrings.splice(index, 1)
-                        console.log('value removed at index', index, 'from', headersStrings)
                         setLocalStorage({ headers: colonSeparatedStringsToMap(headersStrings) })
                     }}
                     onValueAdded={(value) => {
-                        consoleProxy.debug('adding header', value)
                         headersStrings.push(value)
                         setLocalStorage({ headers: colonSeparatedStringsToMap(headersStrings) })
                     }}
@@ -151,6 +123,7 @@ export default function GeneralConfiguration({ enabled }: GeneralConfigurationPr
                     description="Include additional HTTP headers on all export requests."
                     placeholder={headersStrings.length == 0 ? 'key:value, key2:value2' : ''}
                     delimiter={","}
+                    keyValueMode={true}
                 />
             </Group>
         </Fieldset>

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -2,6 +2,7 @@ import { Combobox, Pill, PillsInput, Tooltip, useCombobox } from "@mantine/core"
 import { useClickOutside } from "@mantine/hooks";
 import { IconExclamationCircle } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
+import { parseKeyValuePairs } from "~utils/string";
 
 type PillErrorMap = Map<number, string>
 
@@ -62,7 +63,7 @@ export const TagsInput = ({ delimiter, description, disabled, errors, label, pla
                         handleValueRemoved(i);
                     }
                 }}
-                onFocus={(e) => {
+                onFocus={(event) => {
                     event.preventDefault();
                     handleTagSelected(i)
                 }}
@@ -96,14 +97,12 @@ export const TagsInput = ({ delimiter, description, disabled, errors, label, pla
     }
 
     useEffect(() => {
-        const split = pillInputValue.split(delimiter);
+        const [parsed, remainder] = parseKeyValuePairs(pillInputValue, delimiter);
+        parsed.forEach((value, key) => handleValueSubmit(`${key}:${value}`));
 
-        if (split.length > 1) {
-            const last = split.pop();
-            split.forEach((value) => handleValueSubmit(value.trim()));
-            setPillInputValue(last);
+        if (remainder.length > 0) {
+            setPillInputValue(remainder);
         }
-
     }, [pillInputValue])
 
     return (

--- a/src/components/TagsInput.tsx
+++ b/src/components/TagsInput.tsx
@@ -2,7 +2,6 @@ import { Combobox, Pill, PillsInput, Tooltip, useCombobox } from "@mantine/core"
 import { useClickOutside } from "@mantine/hooks";
 import { IconExclamationCircle } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
-import { consoleProxy } from "~utils/logging";
 import { parseKeyValuePairs } from "~utils/string";
 
 type PillErrorMap = Map<number, string>
@@ -13,6 +12,7 @@ type TagsInputProps = {
     disabled?: boolean
     error?: string
     errors?: PillErrorMap
+    keyValueMode?: boolean
     label: string | React.ReactNode
     placeholder: string
     value: React.ReactNode[] | string[]
@@ -21,7 +21,7 @@ type TagsInputProps = {
     onTagSelected?: (index: number) => void
 }
 
-export const TagsInput = ({ delimiter, description, disabled, errors, label, placeholder, value, onValueRemoved, onValueAdded, onTagSelected }: TagsInputProps) => {
+export const TagsInput = ({ delimiter, description, disabled, errors, label, placeholder, value, onValueRemoved, onValueAdded, onTagSelected, keyValueMode: kevValueMode = false }: TagsInputProps) => {
     const [selectedIndex, setSelectedIndex] = useState<number>(-1);
     const [pillInputValue, setPillInputValue] = useState<string>('');
     const handleClickOutside = () => setSelectedIndex(-1);
@@ -89,7 +89,6 @@ export const TagsInput = ({ delimiter, description, disabled, errors, label, pla
     }
 
     const handleValueRemoved = (index: number) => {
-        consoleProxy.debug('removing value at index', index);
         onValueRemoved && onValueRemoved(index);
     }
 
@@ -99,11 +98,20 @@ export const TagsInput = ({ delimiter, description, disabled, errors, label, pla
     }
 
     useEffect(() => {
-        const [parsed, remainder] = parseKeyValuePairs(pillInputValue, delimiter);
-        consoleProxy.debug('pill input value changed', parsed, remainder);
 
-        parsed.forEach((value, key) => handleValueSubmit(`${key}:${value}`));
-        setPillInputValue(remainder);
+        if (kevValueMode) {
+            const [parsed, remainder] = parseKeyValuePairs(pillInputValue, delimiter);
+            parsed.forEach((value, key) => handleValueSubmit(`${key}:${value}`));
+            setPillInputValue(remainder);
+        } else {
+            const split = pillInputValue.split(delimiter);
+
+            if (split.length > 1) {
+                const last = split.pop();
+                split.forEach((value) => handleValueSubmit(value.trim()));
+                setPillInputValue(last);
+            }
+        }
     }, [pillInputValue])
 
     return (
@@ -125,21 +133,17 @@ export const TagsInput = ({ delimiter, description, disabled, errors, label, pla
                                 setSelectedIndex(-1);
                             }}
                             onKeyDown={(event) => {
-                                if (event.key === 'Backspace') {
-
-                                    consoleProxy.debug('backspace key pressed', selectedIndex, pillInputValue.length);
-
-                                    if (selectedIndex !== -1 || pillInputValue.length === 0) {
-                                        event.preventDefault();
-                                        handleValueRemoved(selectedIndex)
-                                    }
+                                if (event.key === 'Backspace' && (selectedIndex !== -1 || pillInputValue.length === 0)) {
+                                    event.preventDefault();
+                                    handleValueRemoved(selectedIndex)
                                 }
                                 else if (event.key === 'Enter') {
 
                                     if (pillInputValue.length > 0) {
+
                                         const [kvs, _] = parseKeyValuePairs(pillInputValue, delimiter, false);
 
-                                        if (kvs.size > 0) {
+                                        if (!kevValueMode || kvs.size > 0) {
                                             handleValueSubmit(pillInputValue);
                                             setPillInputValue('');
                                         }

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,0 +1,87 @@
+import assert from 'assert';
+import { parseKeyValuePairs } from './string';
+
+describe("string", () => {
+
+    describe("parseKeyValuePairs", () => {
+        it('parses a string with a single key-value pair with no remainder', () => {
+            const input = 'key:value';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = { key: 'value' };
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+
+        it('parses a string with a single key-value pair with no remainder and preserves any internal whitespace', () => {
+            const input = 'key:va    lue';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = { key: 'va    lue' };
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+
+        it('parses a string with a single key-value pair with matched quotes', () => {
+            const input = 'key:"value\'s"';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = { key: "value's" };
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+
+        it('parses a string with a single key-value pair and quoted colons', () => {
+            const input = '"key:abc":"value:def"';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = { "key:abc": "value:def" };
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+
+        it('parses a string with a single key-value pair with value remainder (due to unmatched quotes)', () => {
+            const input = 'key:"value\'s';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = {};
+            const expectedRemainder = 'key:"value\'s';
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, expectedRemainder);
+        });
+
+        it('parses a string with key remainder and an unmatched quote', () => {
+            const input = '"key:';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = {};
+            const expectedRemainder = '"key:';
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, expectedRemainder);
+        });
+
+        it('parses a string with multiple key-value pairs with quoted and un-quoted commas', () => {
+            const input = 'key:"val,ue\'s",another-key:val,ue:with:colons';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = { key: "val,ue's", 'another-key': 'val', ue: 'with:colons' };
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+
+        it('parses a string with multiple key-value pairs with quoted and un-quoted commas and colons', () => {
+            const input = '"key:,\'":"val,ue\'s",another-key:"val,ue:with:colons"';
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = { "key:,'": "val,ue's", 'another-key': "val,ue:with:colons" };
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+
+        it('parses a complicated string with quotes and commas with no remainder', () => {
+            const input = `unquoted-example:abc\\"def,   example-key:"not-necessarily-\\"quoted\\"-value",   another-key:'a-different-set-\\"of-quotes\\"',  tricky-case:"there'saquoteinside\\",andadelimiter",  incomplete-key:unfin'ished'`;
+            const [parsedResult, remainder] = parseKeyValuePairs(input);
+            const expected = {
+                'unquoted-example': 'abc"def',
+                'example-key': 'not-necessarily-"quoted"-value',
+                'another-key': 'a-different-set-"of-quotes"',
+                'tricky-case': `there'saquoteinside",andadelimiter`,
+                'incomplete-key': "unfin'ished'"
+            }
+            assert.deepStrictEqual(parsedResult, expected);
+            assert.strictEqual(remainder, '');
+        });
+    })
+})

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -7,7 +7,7 @@ describe("string", () => {
         it('parses a string with a single key-value pair with no remainder', () => {
             const input = 'key:value';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = { key: 'value' };
+            const expected = new Map([['key', 'value']]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });
@@ -15,7 +15,7 @@ describe("string", () => {
         it('parses a string with a single key-value pair with no remainder and preserves any internal whitespace', () => {
             const input = 'key:va    lue';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = { key: 'va    lue' };
+            const expected = new Map([['key', 'va    lue']]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });
@@ -23,7 +23,7 @@ describe("string", () => {
         it('parses a string with a single key-value pair with matched quotes', () => {
             const input = 'key:"value\'s"';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = { key: "value's" };
+            const expected = new Map([['key', 'value\'s']]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });
@@ -31,7 +31,7 @@ describe("string", () => {
         it('parses a string with a single key-value pair and quoted colons', () => {
             const input = '"key:abc":"value:def"';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = { "key:abc": "value:def" };
+            const expected = new Map([['key:abc', 'value:def']]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });
@@ -39,7 +39,7 @@ describe("string", () => {
         it('parses a string with a single key-value pair with value remainder (due to unmatched quotes)', () => {
             const input = 'key:"value\'s';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = {};
+            const expected = new Map();
             const expectedRemainder = 'key:"value\'s';
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, expectedRemainder);
@@ -48,7 +48,7 @@ describe("string", () => {
         it('parses a string with key remainder and an unmatched quote', () => {
             const input = '"key:';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = {};
+            const expected = new Map();
             const expectedRemainder = '"key:';
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, expectedRemainder);
@@ -57,7 +57,7 @@ describe("string", () => {
         it('parses a string with multiple key-value pairs with quoted and un-quoted commas', () => {
             const input = 'key:"val,ue\'s",another-key:val,ue:with:colons';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = { key: "val,ue's", 'another-key': 'val', ue: 'with:colons' };
+            const expected = new Map([['key', 'val,ue\'s'], ['another-key', 'val'], ['ue', 'with:colons']]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });
@@ -65,7 +65,7 @@ describe("string", () => {
         it('parses a string with multiple key-value pairs with quoted and un-quoted commas and colons', () => {
             const input = '"key:,\'":"val,ue\'s",another-key:"val,ue:with:colons"';
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = { "key:,'": "val,ue's", 'another-key': "val,ue:with:colons" };
+            const expected = new Map([['key:,\'', 'val,ue\'s'], ['another-key', 'val,ue:with:colons']]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });
@@ -73,13 +73,13 @@ describe("string", () => {
         it('parses a complicated string with quotes and commas with no remainder', () => {
             const input = `unquoted-example:abc\\"def,   example-key:"not-necessarily-\\"quoted\\"-value",   another-key:'a-different-set-\\"of-quotes\\"',  tricky-case:"there'saquoteinside\\",andadelimiter",  incomplete-key:unfin'ished'`;
             const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = {
-                'unquoted-example': 'abc"def',
-                'example-key': 'not-necessarily-"quoted"-value',
-                'another-key': 'a-different-set-"of-quotes"',
-                'tricky-case': `there'saquoteinside",andadelimiter`,
-                'incomplete-key': "unfin'ished'"
-            }
+            const expected = new Map([
+                ['unquoted-example', 'abc"def'],
+                ['example-key', 'not-necessarily-"quoted"-value'],
+                ['another-key', 'a-different-set-"of-quotes"'],
+                ['tricky-case', `there'saquoteinside",andadelimiter`],
+                ['incomplete-key', "unfin'ished'"]
+            ]);
             assert.deepStrictEqual(parsedResult, expected);
             assert.strictEqual(remainder, '');
         });

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -4,84 +4,102 @@ import { parseKeyValuePairs } from './string';
 describe("string", () => {
 
     describe("parseKeyValuePairs", () => {
-        it('parses a string with a single key-value pair with no remainder', () => {
-            const input = 'key:value';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([['key', 'value']]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
+
+        describe('with lastRemains = true', () => {
+            it('parses a string with a single key-value pair with no remainder', () => {
+                const input = 'key:value';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([['key', 'value']]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
+
+            it('parses a string with a single key-value pair with no remainder and preserves any internal whitespace', () => {
+                const input = 'key:va    lue';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([['key', 'va    lue']]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
+
+            it('parses a string with a single key-value pair with matched quotes', () => {
+                const input = 'key:"value\'s"';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([['key', 'value\'s']]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
+
+            it('parses a string with a single key-value pair and quoted colons', () => {
+                const input = '"key:abc":"value:def"';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([['key:abc', 'value:def']]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
+
+            it('parses a string with a single key-value pair with value remainder (due to unmatched quotes)', () => {
+                const input = 'key:"value\'s';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map();
+                const expectedRemainder = 'key:"value\'s';
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, expectedRemainder);
+            });
+
+            it('parses a string with key remainder and an unmatched quote', () => {
+                const input = '"key:';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map();
+                const expectedRemainder = '"key:';
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, expectedRemainder);
+            });
+
+            it('parses a string with multiple key-value pairs with quoted and un-quoted commas', () => {
+                const input = 'key:"val,ue\'s",another-key:val,ue:with:colons';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([['key', 'val,ue\'s'], ['another-key', 'val'], ['ue', 'with:colons']]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
+
+            it('parses a string with multiple key-value pairs with quoted and un-quoted commas and colons', () => {
+                const input = '"key:,\'":"val,ue\'s",another-key:"val,ue:with:colons"';
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([['key:,\'', 'val,ue\'s'], ['another-key', 'val,ue:with:colons']]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
+
+            it('parses a complicated string with quotes and commas with no remainder', () => {
+                const input = `unquoted-example:abc\\"def,   example-key:"not-necessarily-\\"quoted\\"-value",   another-key:'a-different-set-\\"of-quotes\\"',  tricky-case:"there'saquoteinside\\",andadelimiter",  incomplete-key:unfin'ished'`;
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',', false);
+                const expected = new Map([
+                    ['unquoted-example', 'abc"def'],
+                    ['example-key', 'not-necessarily-"quoted"-value'],
+                    ['another-key', 'a-different-set-"of-quotes"'],
+                    ['tricky-case', `there'saquoteinside",andadelimiter`],
+                    ['incomplete-key', "unfin'ished'"]
+                ]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, '');
+            });
         });
 
-        it('parses a string with a single key-value pair with no remainder and preserves any internal whitespace', () => {
-            const input = 'key:va    lue';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([['key', 'va    lue']]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
-        });
-
-        it('parses a string with a single key-value pair with matched quotes', () => {
-            const input = 'key:"value\'s"';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([['key', 'value\'s']]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
-        });
-
-        it('parses a string with a single key-value pair and quoted colons', () => {
-            const input = '"key:abc":"value:def"';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([['key:abc', 'value:def']]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
-        });
-
-        it('parses a string with a single key-value pair with value remainder (due to unmatched quotes)', () => {
-            const input = 'key:"value\'s';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map();
-            const expectedRemainder = 'key:"value\'s';
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, expectedRemainder);
-        });
-
-        it('parses a string with key remainder and an unmatched quote', () => {
-            const input = '"key:';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map();
-            const expectedRemainder = '"key:';
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, expectedRemainder);
-        });
-
-        it('parses a string with multiple key-value pairs with quoted and un-quoted commas', () => {
-            const input = 'key:"val,ue\'s",another-key:val,ue:with:colons';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([['key', 'val,ue\'s'], ['another-key', 'val'], ['ue', 'with:colons']]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
-        });
-
-        it('parses a string with multiple key-value pairs with quoted and un-quoted commas and colons', () => {
-            const input = '"key:,\'":"val,ue\'s",another-key:"val,ue:with:colons"';
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([['key:,\'', 'val,ue\'s'], ['another-key', 'val,ue:with:colons']]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
-        });
-
-        it('parses a complicated string with quotes and commas with no remainder', () => {
-            const input = `unquoted-example:abc\\"def,   example-key:"not-necessarily-\\"quoted\\"-value",   another-key:'a-different-set-\\"of-quotes\\"',  tricky-case:"there'saquoteinside\\",andadelimiter",  incomplete-key:unfin'ished'`;
-            const [parsedResult, remainder] = parseKeyValuePairs(input);
-            const expected = new Map([
-                ['unquoted-example', 'abc"def'],
-                ['example-key', 'not-necessarily-"quoted"-value'],
-                ['another-key', 'a-different-set-"of-quotes"'],
-                ['tricky-case', `there'saquoteinside",andadelimiter`],
-                ['incomplete-key', "unfin'ished'"]
-            ]);
-            assert.deepStrictEqual(parsedResult, expected);
-            assert.strictEqual(remainder, '');
-        });
+        describe('with lastRemains = false (for UI entry)', () => {
+            it('parses a complicated string with quotes and commas with last entry remaining', () => {
+                const input = `unquoted-example:abc\\"def,   example-key:"not-necessarily-\\"quoted\\"-value",   another-key:'a-different-set-\\"of-quotes\\"',  tricky-case:"there'saquoteinside\\",andadelimiter",  incomplete-key:unfin'ished'`;
+                const [parsedResult, remainder] = parseKeyValuePairs(input, ',');
+                const expected = new Map([
+                    ['unquoted-example', 'abc"def'],
+                    ['example-key', 'not-necessarily-"quoted"-value'],
+                    ['another-key', 'a-different-set-"of-quotes"'],
+                    ['tricky-case', `there'saquoteinside",andadelimiter`]
+                ]);
+                assert.deepStrictEqual(parsedResult, expected);
+                assert.strictEqual(remainder, "  incomplete-key:unfin'ished'");
+            });
+        })
     })
 })

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,109 @@
+/**
+ * Parses a string of key-value pairs separated by a single-character delimiter, where keys and values are separated by a single colon.
+ * Allows quoting of keys and values using single or double quotes.
+ * 
+ * @param input - The input string to parse.
+ * @param delimiter - The delimiter used to separate key-value pairs. Default is ','.
+ * @returns A tuple containing a `Map<string, string>` of key-value pairs and a remainder string.
+ */
+export const parseKeyValuePairs = (input: string, delimiter: string = ','): [Map<string, string>, string] => {
+    const result: Map<string, string> = new Map();
+    let remainder = '';
+    let key = '';
+    let value = '';
+    let state = 'key';
+    let quoteChar: string | null = null;
+    let escapeNextChar = false;
+    let insideQuotes = false;
+    let afterColon = false;
+
+    for (let i = 0; i < input.length; i++) {
+        const char = input[i];
+
+        if (escapeNextChar) {
+
+            if (state === 'key') {
+                key += char;
+            } else {
+                value += char;
+            }
+            escapeNextChar = false;
+            continue;
+        }
+
+        if (char === '\\') {
+            escapeNextChar = true;
+            continue;
+        }
+
+        switch (state) {
+            case 'key':
+                if (char === ':' && !insideQuotes) {
+                    state = 'value';
+                    afterColon = true;
+                } else if (char === '"' || char === "'") {
+                    if (key === '' && !insideQuotes) {
+                        quoteChar = char;
+                        insideQuotes = true; // Start a new quoted key
+                    } else if (char === quoteChar) {
+                        insideQuotes = false;
+                    } else {
+                        key += char; // Internal quotes within key
+                    }
+                } else {
+                    key += char;
+                }
+                break;
+
+            case 'value':
+                if (afterColon) {
+                    if (char === '"' || char === "'") {
+                        quoteChar = char;
+                        insideQuotes = true; // Start a new quoted value
+                        afterColon = false; // Prevent quotes from being handled as part of value
+                    } else {
+                        insideQuotes = false; // No quote if not the first non-whitespace character after colon
+                        afterColon = false;
+                        value += char; // Handle as normal character
+                    }
+                } else if (insideQuotes) {
+                    if (char === quoteChar) {
+                        // Check for an escaped quote
+                        if (input[i + 1] === quoteChar) {
+                            value += char;
+                            i++; // Skip the next quote
+                        } else {
+                            insideQuotes = false;
+                        }
+                    } else {
+                        value += char;
+                    }
+                } else if (char === delimiter) {
+                    if (!insideQuotes) {
+                        result[key.trim()] = value.trim();
+                        key = '';
+                        value = '';
+                        state = 'key';
+                        afterColon = false;
+                    } else {
+                        value += char;
+                    }
+                } else {
+                    value += char;
+                }
+                break;
+        }
+    }
+
+    // Final key-value pair handling
+    if (state === 'key') {
+        remainder = insideQuotes ? `${quoteChar}${key}` : key; // Include the open quote in remainder
+    } else if (state === 'value') {
+        if (insideQuotes) {
+            remainder = `${key}:${quoteChar}${value}`; // Include the open quote in remainder
+        } else {
+            result[key.trim()] = value.trim();
+        }
+    }
+    return [result, remainder];
+}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -80,7 +80,7 @@ export const parseKeyValuePairs = (input: string, delimiter: string = ','): [Map
                     }
                 } else if (char === delimiter) {
                     if (!insideQuotes) {
-                        result[key.trim()] = value.trim();
+                        result.set(key.trim(), value.trim());
                         key = '';
                         value = '';
                         state = 'key';
@@ -102,7 +102,7 @@ export const parseKeyValuePairs = (input: string, delimiter: string = ','): [Map
         if (insideQuotes) {
             remainder = `${key}:${quoteChar}${value}`; // Include the open quote in remainder
         } else {
-            result[key.trim()] = value.trim();
+            result.set(key.trim(), value.trim());
         }
     }
     return [result, remainder];

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,5 @@
+import { consoleProxy } from "./logging";
+
 /**
  * Parses a string of key-value pairs separated by a single-character delimiter, where keys and values are separated by a single colon.
  * Allows quoting of keys and values using single or double quotes.
@@ -117,4 +119,29 @@ export const parseKeyValuePairs = (input: string, delimiter: string = ',', lastR
         }
     }
     return [result, remainder];
+}
+
+export const colonSeparatedStringsToMap = (strings: string[]): Map<string, string> => {
+    const map = new Map<string, string>()
+    strings.forEach((string) => {
+        const [kvs, _] = parseKeyValuePairs(string, ',', false)
+        consoleProxy.debug('parsed kvs', kvs, 'for string', string)
+
+        kvs.forEach((value, key) => {
+            map.set(key, value)
+        })
+    })
+    consoleProxy.debug('converted strings to map', map)
+    return map
+}
+
+export const mapToColonSeparatedStrings = (map: Map<string, string>): string[] => {
+    const strings = []
+    if (map) {
+        map.forEach((value, key) => {
+            strings.push(`${key}:${value}`)
+        })
+    }
+    consoleProxy.debug('converted map to strings', strings, 'from map', map)
+    return strings
 }


### PR DESCRIPTION
To hopefully be replaced with a better parser/UI component rather than this hand-rolled implementation which likely has some weird edge cases. Technically allows erroneous request headers containing colons, but software development without providing footguns misses valuable opportunities for ~natural selection~ learning.

Also adds support for preventing Firefox CSP from automatically upgrading `http` requests to `https` (via the browser-specific `overrides` feature that I contributed to Plasmo).